### PR TITLE
重构 china-national-standard-gb-t-7714-2015-numeric.csl

### DIFF
--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -1,25 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="zh-CN" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" ">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" names-delimiter=". " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
-    <title>China National Standard GB/T 7714-2015 (numeric, Chinese)</title>
+    <title>China National Standard GB/T 7714-2015 (numeric, 中文)</title>
     <title-short>GB/T 7714-2015</title-short>
     <id>http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric</id>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="self"/>
-    <link href="http://www.std.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>牛耕田</name>
       <email>buffalo_d@163.com</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>The Chinese GB/T7714-2015 numeric style</summary>
-    <updated>2019-04-27T18:00:00+08:00</updated>
+    <updated>2021-11-14T09:44:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
     <terms>
-      <term name="anonymous">佚名</term>
-      <term name="edition">版</term>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
       <term name="page" form="short">
         <single>p.</single>
         <multiple>pp.</multiple>
@@ -27,52 +39,154 @@
     </terms>
   </locale>
   <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
     <terms>
       <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
+  <!-- 引用日期 -->
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
-      <date-part name="year"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="day" form="numeric-leading-zeros"/>
-    </date>
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
   </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name>
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given"/>
-          </name>
-        </names>
-      </if>
-      <else>
-        <text term="anonymous"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author">
+    <names variable="author">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
     </names>
   </macro>
-  <macro name="edition">
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
     <choose>
-      <if variable="edition">
-        <group delimiter=" ">
-          <text variable="edition"/>
-          <text term="edition"/>
-        </group>
+      <if type="article article-journal article-magazine article-newspaper" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>
-  <macro name="editor">
-    <names variable="editor translator">
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <date variable="event-date" form="text"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <choose>
+          <if variable="URL DOI" match="none">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="publisher page" match="any">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <if variable="URL DOI" match="any">
+        <choose>
+          <if variable="publisher" match="none">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
@@ -80,212 +194,201 @@
       <label form="short" prefix=", "/>
     </names>
   </macro>
-  <macro name="issued-date">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" delimiter="-">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-date-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publishing">
-    <choose>
-      <if variable="publisher">
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
           <group delimiter=", ">
-            <text variable="publisher"/>
-            <text macro="issue-date-year"/>
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
           </group>
+          <text variable="issue" prefix="(" suffix=")"/>
         </group>
-        <text variable="page" prefix=": "/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="serial-information">
-    <group delimiter=", ">
-      <text macro="issue-date-year"/>
-      <text variable="volume"/>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
   </macro>
-  <macro name="type-code">
-    <choose>
-      <if type="article-journal article-magazine" match="any">
-        <text value="J"/>
-      </if>
-      <else-if type="article-newspaper">
-        <text value="N"/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text value="S"/>
-      </else-if>
-      <else-if type="book">
-        <text value="M"/>
-      </else-if>
-      <else-if type="chapter">
-        <text value="M"/>
-      </else-if>
-      <else-if type="dataset">
-        <text value="DS"/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text value="C"/>
-      </else-if>
-      <else-if type="patent">
-        <text value="P"/>
-      </else-if>
-      <else-if type="post-weblog webpage" match="any">
-        <text value="EB"/>
-      </else-if>
-      <else-if type="report">
-        <text value="R"/>
-      </else-if>
-      <else-if type="thesis">
-        <text value="D"/>
-      </else-if>
-      <else>
-        <text value="Z"/>
-      </else>
-    </choose>
-  </macro>
+  <!-- 题名 -->
   <macro name="title">
-    <text variable="title" text-case="title"/>
-    <text variable="number" prefix=": "/>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-code"/>
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <choose>
+          <if variable="number">
+            <text variable="number"/>
+          </if>
+          <else-if variable="container-title" type="paper-conference" match="none">
+            <text macro="book-volume"/>
+          </else-if>
+        </choose>
+      </group>
       <choose>
-        <if variable="URL">
+        <if variable="container-title" type="paper-conference" match="none">
+          <text variable="event-place"/>
+          <date variable="event-date" form="text"/>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill legislation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
           <text value="OL"/>
         </if>
       </choose>
     </group>
   </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
   <citation collapse="citation-number" after-collapse-delimiter=",">
-    <sort>
-      <key variable="citation-number" sort="ascending"/>
-    </sort>
     <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
       <text variable="citation-number"/>
       <group prefix="(" suffix=")">
+        <!-- 国标要求在方括号外著录引文页码，但是跟同处引用多篇文献的情况冲突，在 CSL 中无法实现 -->
         <label variable="locator" suffix=". " form="short" strip-periods="true"/>
         <text variable="locator"/>
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
-    <layout suffix="." locale="en">
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <layout locale="en">
       <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" suffix=". "/>
-      <text macro="title"/>
-      <choose>
-        <if type="book bill chapter legislation paper-conference report thesis" match="any">
-          <text macro="editor" prefix=". "/>
-          <choose>
-            <if variable="container-title">
-              <text value="//"/>
-              <text macro="container-author" suffix=". "/>
-              <text variable="container-title" suffix=". " text-case="title"/>
-            </if>
-            <else>
-              <text value=". "/>
-            </else>
-          </choose>
-          <text macro="edition" suffix=". "/>
-          <text macro="publishing"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper" match="any">
-          <group prefix=". ">
-            <choose>
-              <if variable="container-title">
-                <text variable="container-title" text-case="title"/>
-                <text macro="serial-information" prefix=", "/>
-              </if>
-              <else>
-                <text macro="serial-information" suffix=". "/>
-                <text macro="publishing"/>
-              </else>
-            </choose>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <text macro="issued-date" prefix=". "/>
-        </else-if>
-        <else>
-          <text macro="publishing" prefix=". "/>
-          <text macro="issued-date" prefix="(" suffix=")"/>
-        </else>
-      </choose>
-      <text macro="accessed-date"/>
-      <group delimiter=". " prefix=". ">
-        <text variable="URL"/>
-        <text variable="DOI" prefix="DOI:"/>
-      </group>
+      <text macro="entry-layout"/>
     </layout>
-    <layout suffix=".">
+    <layout>
       <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" suffix=". "/>
-      <text macro="title"/>
-      <choose>
-        <if type="book bill chapter legislation paper-conference report thesis" match="any">
-          <text macro="editor" prefix=". "/>
-          <choose>
-            <if variable="container-title">
-              <text value="//"/>
-              <text macro="container-author" suffix=". "/>
-              <text variable="container-title" suffix=". " text-case="title"/>
-            </if>
-            <else>
-              <text value=". "/>
-            </else>
-          </choose>
-          <text macro="edition" suffix=". "/>
-          <text macro="publishing"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper" match="any">
-          <group prefix=". ">
-            <choose>
-              <if variable="container-title">
-                <text variable="container-title" text-case="title"/>
-                <text macro="serial-information" prefix=", "/>
-              </if>
-              <else>
-                <text macro="serial-information" suffix=". "/>
-                <text macro="publishing"/>
-              </else>
-            </choose>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <text macro="issued-date" prefix=". "/>
-        </else-if>
-        <else>
-          <text macro="publishing" prefix=". "/>
-          <text macro="issued-date" prefix="(" suffix=")"/>
-        </else>
-      </choose>
-      <text macro="accessed-date"/>
-      <group delimiter=". " prefix=". ">
-        <text variable="URL"/>
-        <text variable="DOI" prefix="DOI:"/>
-      </group>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
现版本的 `china-national-standard-gb-t-7714-2015-*.csl` 与国标的格式有许多差异。我在另一个仓库整理了国标的大部分示例 [gbt7714-numeric.txt](https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/blob/standard/gbt7714-numeric.txt)，以及结构化的 CSL-JSON 输入数据 [gbt7714-numeric-data.json](https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/blob/main/gbt7714-numeric-data.json)（可导入 Zotero，先前版本导入失败是因为用了 CSL v1.0.2 新增的文献类型）。 现版本 CSL 输出的参考文献与国标的格式对比：<https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/compare/standard...original>，其中未使用 CSL-M 的多语言功能。

重构后的 CSL 生成的参考文献与国标的对比：[zepinglee/china-national-standard-gb-t-7714-2015@standard...main](https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/compare/standard...main#diff-cfbf4589528ea9beaeebb77942283da69f584518d16eefcb63677b17ea328615)，其中还有一些差异，但据我了解在目前 CSL v1.0.1 的版本下应该无法实现。


以下是主要修改的记录（用英文写的，应该不需要翻译）。

1. Allow editor name to be the primary contributor of a book instead the anonymous term.
2. The anonymous term is omitted in numeric and note styles as specified in the standard.
3. Use sentence case (actually no case conversion) for titles and container titles instead of title case. This is not explicitly specified in the style but is used in the all the examples.
4. The names of proceeding editor are moved after the "//" mark (which is similar to "In:").
5. The edition number is now checked if it is numeric for output.
6. Change `page-range-delimiter` to hyphen as specified in the standard, which is similar to Vancouver style.
7. Correct the hyphens in ISO dates (yyyy-mm-dd) from en dashes.
8. Fix missing issued date in `report` type.
9. Split the bibliography layout into categories so that the code structure is more clear.
10. Cite items are not sorted. It's not specified in the standard and a citation example with reverse-ordered citation-numbers appears.
11. A space is inserted in the author-date citation ahead of `et-al` term in Chinese, which is required by the standard.