### PR TITLE
调整了一下 301 法学引注手册的 < bibliography >

### DIFF
--- a/301law-citation-manual-multi-lingual.csl
+++ b/301law-citation-manual-multi-lingual.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>法学引注手册</summary>
-    <updated>2022-05-08T14:54:00+08:00</updated>
+    <updated>2022-05-24T14:54:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh">
@@ -540,13 +540,13 @@
       <text macro="citation-layout"/>
     </layout>
   </citation>
-  <bibliography second-field-align="flush">
+  <bibliography entry-spacing="0" >
     <layout locale="en" suffix=".">
-      <text variable="citation-number" prefix="〔" suffix="〕"/>
+      <text variable="citation-number" prefix="   〔" suffix="〕"/>
       <text macro="source-en"/>
     </layout>
     <layout suffix="。">
-      <text variable="citation-number" prefix="〔" suffix="〕"/>
+      <text variable="citation-number" prefix="   〔" suffix="〕"/>
       <text macro="source"/>
     </layout>
   </bibliography>


### PR DESCRIPTION
对照《法学引注手册》，感觉有三个地方可以优化一下：

- 序号和作者名之间隔得有点开
  法学引注手册用全角的六角括号作为 prefix，本来序号和作者名就会隔得比较开。使用 `flush` 对齐后，就隔得更开了，这里取消了 `flush` 对齐；

- 根据《手册》的示例，取消了段后距 & 增加首行缩进

在 Word 中进行了测试，配合适当的 Word 样式，出来的结果基本和《手册》一致了：

![20220524-法学引注手册](https://user-images.githubusercontent.com/77708899/170222991-8b160f52-769a-465c-a22f-79418e5c2827.png)

![20220524-法学引注手册-样式修改后](https://user-images.githubusercontent.com/77708899/170223084-8487fce3-f369-45ef-8403-ba2defb3aa78.png)

谢谢