### PR TITLE
更新无机材料学报 2022-10-27

### DIFF
--- a/106journal-of-inorganic-materials.csl
+++ b/106journal-of-inorganic-materials.csl
@@ -4,7 +4,7 @@
     <title>无机材料学报</title>
     <id>http://www.zotero.org/styles/journal-of-inorganic-materials</id>
     <link href="http://www.zotero.org/styles/journal-of-inorganic-materials" rel="self"/>
-    <link href="http://www.jim.org.cn/CN/column/item6.shtml" rel="documentation"/>
+    <link href="http://www.jim.org.cn/CN/column/item63.shtml" rel="documentation"/>
     <author>
       <name>Northword</name>
       <website>https://github.com/northword</website>
@@ -13,7 +13,7 @@
     <category field="generic-base"/>
     <summary>无机材料学报</summary>
     <published>2022-03-24</published>
-    <updated>2022-12-02T17:49:29+08:00</updated>
+    <updated>2023-1-26T11:34:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
@@ -45,6 +45,8 @@
             <name-part name="family" text-case="uppercase"/>
             <name-part name="given" text-case="uppercase"/>
           </name>
+          <et-al font-style="italic"/>
+          <!--期刊要求 et al 加粗-->
         </names>
       </if>
       <else>
@@ -118,8 +120,19 @@
       <text macro="issue-date-year"/>
       <text variable="volume" font-weight="bold"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")" font-weight="bold"/>
-    <text variable="page" prefix=": "/>
+    <group font-weight="bold">
+      <!--期刊要求括号加粗，font-weight 放入 text 不合要求-->
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+    <group>
+      <choose>
+        <if variable="page">
+          <text value=": " font-weight="bold" />
+          <text variable="page"/>
+        </if>
+        <!--期刊要求冒号加粗-->
+      </choose>
+    </group>
   </macro>
   <macro name="title">
     <text variable="title" text-case="capitalize-first"/>
@@ -129,6 +142,18 @@
     <choose>
       <if type="webpage post-weblog" match="any">
         <text variable="URL"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="DOI">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <choose>
+          <if variable="page"></if>
+          <else>
+            <text variable="DOI"  prefix="DOI: " />
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -190,7 +215,7 @@
       <text macro="accessed-date"/>
       <group delimiter=". " prefix=". ">
         <text macro="URL"/>
-        <!-- <text variable="DOI" prefix="DOI:"/> -->
+        <text macro="DOI"/>
       </group>
     </layout>
     <layout suffix=".">
@@ -238,7 +263,7 @@
       <text macro="accessed-date"/>
       <group delimiter=". " prefix=". ">
         <text macro="URL"/>
-        <!-- <text variable="DOI" prefix="DOI:"/> -->
+        <text macro="DOI"/>
       </group>
     </layout>
   </bibliography>

--- a/README.md
+++ b/README.md
@@ -430,16 +430,18 @@ L ang Rongrong, Li Nan, Wang Renhuan. The establishmentof evaluating PSE-like ch
 
 《无机材料学报》（<http://www.jim.org.cn/CN/column/item6.shtml>）期刊用，ISSN:1000-324X，CN:31-1363/TQ。
 
-作者`(姓前名后，名缩写，全部大写)`. 题名`(第一个单词首字母大写)`. *期刊名*`(斜体)`, 出版年, **卷(期)**`(加粗)`: 起始页—终止页。
+作者`(姓前名后，名缩写，全部大写，三人缩写，et al斜体)`. 题名`(第一个单词首字母大写)`. *期刊名*`(斜体)`, 出版年, **卷(期):**`(加粗)` 起始页—终止页。
 
 显示效果：
-> [1–4]
 
-> [1]	LI Y, TANG F, WANG D, et al. A key step for preparing highly active Mg–Co composite oxide catalysts for N2O decomposition. *Catalysis Science & Technology*, 2021, **11(11)**: 3737–3745.</br>
-> [2]	RESASCO D E, HALLER G L. A model of metal-oxide support interaction for Rh on TiO2. *Journal of Catalysis*, 1983, **82(2)**: 279–288.</br>
-> [3]	LIU H, SHEN K, ZHAO H, et al. A new strategy to improve catalytic activity for chlorinated volatile organic compounds oxidation over cobalt oxide: Introduction of strontium carbonate. *Journal of the Indian Chemical Society*, 2021, **98(8)**: 100116.</br>
-> [4]	DAMMA D, ETTIREDDY P, REDDY B, et al. A Review of Low Temperature NH3-SCR for Removal of NOx. *Catalysts*, 2019, **9(4)**: 349.
-
+> [1–5]
+>
+> [1] FANG X, QU W, QIN T, *et al.* Abatement of Nitrogen Oxides via Selective Catalytic Reduction over Ce1–W1 Atom-Pair Sites. *Environmental Science & Technology*, 2022, **56(10):** 6631–6638. </br>
+> [2] FANG X, LIU Y, CEN W, *et al.* Birnessite as a Highly Efficient Catalyst for Low-Temperature NH3-SCR: The Vital Role of Surface Oxygen Vacancies. *Industrial & Engineering Chemistry Research*, 2020, **59(33):** 14606–14615. </br>
+> [3] ZHANG J, ZHANG L, CHENG Y, *et al.* Construction of oxygen vacancies in δ-MnO2 for promoting low-temperature toluene oxidation. *Fuel*, 2023, **332:** 126104. </br>
+> [4] FENG X, GUO J, WEN X, *et al.* Enhancing performance of Co/CeO2 catalyst by Sr doping for catalytic combustion of toluene. *Applied Surface Science*, 2018, **445:** 145–153. </br>
+> [5] HU Y, ZHANG L, ZHANG J, *et al.* High catalytic performance of neodymium modified Co3O4 for toluene oxidation. *Journal of Rare Earths*, 2022. DOI: [10.1016/j.jre.2022.09.019](https://doi.org/10.1016/j.jre.2022.09.019). </br>
+> [6] FANG X, LIU Y, CHEN L, *et al.* Influence of surface active groups on SO2 resistance of birnessite for low-temperature NH3-SCR. *Chemical Engineering Journal*, 2020, **399:** 125798.
 
 ## [107chinese-journal-of-cardiology.csl]
 


### PR DESCRIPTION
根据 [期刊更新的投稿要求](http://www.jim.org.cn/CN/column/item63.shtml)，将 `et-al` 设为斜体，将 `期(卷): ` （含冒号）设为粗体，未正式刊发的期刊文章（无起始页码）显示 DOI。