### PR TITLE
增加西安交通大学研究生学位论文样式

### DIFF
--- a/438XJTU-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi.csl
+++ b/438XJTU-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi.csl
@@ -1,0 +1,559 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="en-US">
+  <info>
+    <title>西安交通大学学位论文2015</title>
+    <id>http://www.zotero.org/styles/xjtu-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi</id>
+    <link href="http://www.zotero.org/styles/xjtu-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi" rel="self"/>
+    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <author>
+      <name>牛耕田</name>
+      <email>buffalo_d@163.com</email>
+    </author>
+    <contributor>
+      <name>韩小土</name>
+      <email>redleafnew@163.com</email>
+    </contributor>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>pencilheart</name>
+      <email>495474804@qq.com</email>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>1. 按照语言显示“等”或“et al.”；2. 姓名取消全大写；3. 仅纯电子资源显示引用日期和 URL；4. 无 DOI。新增: 5.patten加入place; 6.中文“等”前取消逗号; 7.添加载体”[/CD]”等; 8:standard的title置后</summary>
+    <updated>2022-12-02T17:49:28+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
+    <terms>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <choose>
+      <!-- 仅纯电子资源显示引用日期 -->
+      <if type="article-journal article-magazine article-newspaper bill book chapter legal_case legislation paper-conference periodical standard thesis treaty" variable="publisher page" match="none">
+        <choose>
+          <if variable="URL" match="any">
+            <date variable="accessed" form="numeric" prefix=" [" suffix="]"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 主要责任者 -->
+  <macro name="author">
+    <names variable="author">
+      <name/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 中文主要责任者 -->
+  <macro name="author-zh">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name initialize="false" delimiter="，" delimiter-precedes-et-al="never"/>
+        </names>
+      </if>
+      <else>
+        <text term="anonymous"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-booklike">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event-title"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（刊名、年、卷、期等信息） -->
+  <macro name="container-periodical">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸只有刊名、日期和版次（page） -->
+        <group delimiter=", ">
+          <text variable="container-title"/>
+          <text macro="issued-date"/>
+        </group>
+        <text variable="page" prefix="(" suffix=")"/>
+      </if>
+      <else>
+        <!-- 普通期刊 -->
+        <group delimiter=": ">
+          <group>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" text-case="title"/>
+              <text macro="issued-year"/>
+              <text variable="volume"/>
+            </group>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <!-- 非电子资源显示“出版年” -->
+        <choose>
+          <if type="article-journal article-magazine article-newspaper bill book chapter legal_case legislation paper-conference patent periodical standard thesis treaty" variable="publisher page" match="any">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="URL" match="none">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if type="article-journal article-magazine article-newspaper bill book chapter legal_case legislation paper-conference patent periodical standard thesis treaty" variable="publisher page" match="none">
+        <choose>
+          <if variable="URL" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=". ">
+      <choose>
+        <if type="standard" match="all">
+          <text variable="number"/>
+        </if>
+      </choose>
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="title"/>
+          <choose>
+            <if type="patent" match="all">
+              <text variable="event-place"/>
+            </if>
+          </choose>
+        </group>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="chapter paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="bill legal_case legislation patent regulation report" match="any">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </group>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if>
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <!-- 仅纯电子资源extra中“medium: DK”显示载体：DK(disk),MT(magnetic tape), CD(CD-ROM), OL(online)。常规variable见https://docs.citationstyles.org/en/stable/specification.html#name-variable-terms网页 -->
+        <if type="article-journal article-magazine article-newspaper bill book chapter legal_case legislation paper-conference periodical standard thesis treaty" match="none">
+          <choose>
+            <if variable="medium">
+              <text variable="medium"/>
+            </if>
+          </choose>
+          <choose>
+            <!-- 纯电子资源且无page则显示“OL” -->
+            <if variable="publisher page" match="none">
+              <choose>
+                <if variable="URL" match="any">
+                  <text value="OL"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <choose>
+      <!-- 仅纯电子资源显示 URL -->
+      <if type="article-journal article-magazine article-newspaper bill book chapter legal_case legislation paper-conference periodical standard thesis treaty" variable="publisher page" match="none">
+        <text variable="URL"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group delimiter=", ">
+      <text macro="issued-year"/>
+      <text variable="volume"/>
+    </group>
+    <text variable="issue" prefix="(" suffix=")"/>
+  </macro>
+  <!-- en专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- en专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-booklike"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- en连续出版物 -->
+  <macro name="periodical-layout">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- en连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="container-periodical"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- en专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- zh专著和电子资源 -->
+  <macro name="monograph-layout-zh">
+    <group delimiter=". ">
+      <text macro="author-zh"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- zh专著中的析出文献 -->
+  <macro name="chapter-in-book-layout-zh">
+    <group delimiter=". ">
+      <text macro="author-zh"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-booklike"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- zh连续出版物 -->
+  <macro name="periodical-layout-zh">
+    <group delimiter=". ">
+      <text macro="author-zh"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- zh连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout-zh">
+    <group delimiter=". ">
+      <text macro="author-zh"/>
+      <text macro="title"/>
+      <text macro="container-periodical"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- zh专利文献 -->
+  <macro name="patent-layout-zh">
+    <group delimiter=". ">
+      <text macro="author-zh"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- en参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="periodical-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="chapter paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- zh参考文献表格式 -->
+  <macro name="entry-layout-zh">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout-zh"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="periodical-layout-zh"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout-zh"/>
+      </else-if>
+      <else-if type="chapter paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout-zh"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <!-- zh格式 -->
+    <layout suffix="." locale="zh-CN">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-zh"/>
+    </layout>
+    <!-- en格式 -->
+    <layout suffix=".">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
+    </layout>
+  </bibliography>
+</style>

--- a/438xian-jiaotong-university.csl
+++ b/438xian-jiaotong-university.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="en-US">
   <info>
-    <title>西安交通大学学位论文2015</title>
+    <title>西安交通大学</title>
     <id>http://www.zotero.org/styles/xjtu-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi</id>
     <link href="http://www.zotero.org/styles/xjtu-gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi" rel="self"/>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>

--- a/README.md
+++ b/README.md
@@ -1712,6 +1712,36 @@ Bartov, E.; Mohanram, P. and Seethamraju, C. “Valuation of Internet Stocks—A
   </div>
 </blockquote>
 
+## [438xian-jiaotong-university.csl]
+
+根据《[西安交通大学硕士、博士学位论文模板-2021版](https://gs.xjtu.edu.cn/info/1209/7605.htm)》修订。
+
+显示效果：
+
+> <sup>[1-11]</sup>
+
+> [1]  刘国钧，郑如斯. 中国书的故事[M]. 北京: 中国青年出版社, 1979.
+>
+> [2]  冯西桥. 核反应堆管道和压力容器的LBB分析[R]. 北京: 核能技术设计研究院, 1997.
+>
+> [3]  张国栋. 磁流流体方程的解耦算法及保结构预处理方法[D]. 西安: 西安交通大学, 2018.
+>
+> [4]  全国信息与文献标准化技术委员会第七委员会. GB/T 5795-2002. 中国标准书号[S]. 北京: 中国标准出版社, 2002.
+>
+> [5]  钟文发. 非线性规划在可燃毒物配置中的应用[C]//赵玮. 运筹学的理论与应用: 中国运筹学会第五届大会论文集. 西安: 西安电子科技大学出版社, 1996: 468-471.
+>
+> [6]  高义民，张凤华，邢建东等. 颗粒增强不锈钢基复合材料冲蚀磨损性能研究[J]. 西安交通大学学报, 2001, 35(7): 727-730.
+>
+> [7]  Papworth A, Fox P. Ability of aluminum alloys to wet alumina fibres by addition of bismuth[J]. Mater. Sci. Technol., 1999, 15(4): 419-426.
+>
+> [8]  丁文详. 数字革命与竞争国际化[N]. 中国青年报, 2000-11-20(15).
+>
+> [9]  姜锡洲. 一种温热外敷药制备方案: 中国, 881056078[P]. 1989-07-26.
+>
+> [10] Koseki A, Momose H, Kawahito M, et al. Compiler: US, 828402[P/OL]. 2002-05-25 [2002-05-28]. http://FF&p.
+>
+> [11] Scitor Corporation. Project scheduler[CP/DK]. Sunnyvale, Calif.: Scitor Corporation, 1983.
+  
 ## 501-506
 
 主要用于与Zutilo结合，快速导出部分字段，详见<https://zhuanlan.zhihu.com/p/597826044>。
@@ -2006,3 +2036,4 @@ WPS Office中添加Zotero工具条的方法<https://zhuanlan.zhihu.com/p/5802059
 [434shandong-agricultural-university.csl]:434shandong-agricultural-university.csl
 [435yangzhou-university.csl]:435yangzhou-university.csl
 [436wuhan-university-undergraduate.csl]:436wuhan-university-undergraduate.csl
+[438xian-jiaotong-university.csl]:438xian-jiaotong-university.csl


### PR DESCRIPTION
**样式信息**


- 期刊/学校名称：[西安交通大学研究生学位论文]

- 英文名称：[Xi'an Jiaotong University]

- 参考文献格式要求的**官网**链接[<https://gs.xjtu.edu.cn/system/_content/download.jsp?urltype=news.DownloadAttachUrl&owner=1510757228&wbfileid=4579948>]

Zotero ID: hanheihei

**修改内容**
基于[002gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi](https://github.com/redleafnew/Chinese-STD-GB-T-7714-related-csl/blob/main/002gb-t-7714-2015-numeric-bilingual-no-uppercase-no-url-doi.csl) 修改：

- [x] 中文“等”前取消逗号
- [x] 添加载体”[/DK]”等
- [x] patten添加place
- [x] standard的title与number位置互换
- [x] 默认语言改为en-US，支持期刊缩写


目前已修改完成，请求添加此CSL。左为学位论文要求，右为此CSL。


<img width="1439" alt="image" src="https://user-images.githubusercontent.com/61617063/217924878-63076fcc-4ba8-4fec-a3bb-aecdca356b62.png">

