### PR TITLE
Update 454dalian-maritime-university.csl

### DIFF
--- a/454dalian-maritime-university.csl
+++ b/454dalian-maritime-university.csl
@@ -299,8 +299,9 @@
           <group delimiter="">
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
-            <text macro="issued-year" suffix=": "/>
-            <text macro="book_seleced_page" suffix="."/>
+            <text macro="issued-year" />
+            <text macro="book_seleced_page" prefix=":"/>
+            <text suffix="."/>
           </group>
         </group>
       </else-if>


### PR DESCRIPTION
更新图书M的引用。修复当图书不填写页码时，会多出一个：的问题。