### PR TITLE
华中科技大学：修改了作者个数和缩写问题，参考最新学位论文要求。

### DIFF
--- a/418huazhong-university-of-science-and-technology.csl
+++ b/418huazhong-university-of-science-and-technology.csl
@@ -17,6 +17,7 @@
     </contributor>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
+    <summary>中文文献（含图书、期刊论文、会议论文、专利等）：作者按中文写法，姓在前、名在后；英文文献（含图书、期刊论文、会议论文、专利等）：作者按英文习惯写法，名在前、姓在后，名和姓均用全称，如果作者名超过两个单词，中间名使用简称，如“C.”，不要混用。3人以内列出全部作者，3人以上列出3人再加“等”（英文加“et al”）。每个参考文献的最后不加标点符号。</summary>
     <updated>2023-10-10T14:23:10+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -59,7 +60,8 @@
   <!-- 主要责任者 -->
   <macro name="author">
     <names variable="author">
-      <name/>
+    <!-- 作者缩写改为全称 -->
+      <name initialize='false'/>
       <substitute>
         <names variable="composer"/>
         <names variable="illustrator"/>
@@ -412,7 +414,8 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="7" et-al-use-first="6" second-field-align="flush" line-spacing="1.5">
+  <!-- 参考文献表, 作者个数不超过3个 -->
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush" line-spacing="1.5">
     <layout locale="en">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="entry-layout-en"/>


### PR DESCRIPTION
中文文献（含图书、期刊论文、会议论文、专利等）：作者按中文写法，姓在前、名在后；英文文献（含图书、期刊论文、会议论文、专利等）：作者按英文习惯写法，名在前、姓在后，名和姓均用全称，如果作者名超过两个单词，中间名使用简称，如“C.”，不要混用。3人以内列出全部作者，3人以上列出3人再加“等”（英文加“et al”）。每个参考文献的最后不加标点符号。

参考文献（举例）
[1]	闫明礼，张东刚. CFG桩复合地基技术及工程实践（第二版）. 北京：中国水利水电出版社，2006
[2]	Martin Chalfie, Steven R. Kain. Green fluorescent protein: properties, applications, and protocols. Hoboken, New Jersey: Wiley-interscience, 1998
[3]	詹向红，李德新. 中医药防治阿尔茨海默病实验研究述要. 中华中医药学刊，2004, 22(11): 2094-2096
[4]	Ed S. Lein, Michael J. Hawrylycz, Nancy Ao, et al. Genome-wide atlas of gene expression in the adult mouse brain. Nature, 2007, 445(7124): 168-176
[5]	Mary L Bouxsein, Stephen K Boyd, Blaine A Christiansen,et al. Guidelines for assessment of bone microstructure in rodents using micro–computed tomography. Journal of Bone and Mineral Research, 2010, 25(7): 1468-1486
