### PR TITLE
华中科技大学：补充了最新版版本信息以及相关模板地址

### DIFF
--- a/418huazhong-university-of-science-and-technology.csl
+++ b/418huazhong-university-of-science-and-technology.csl
@@ -6,7 +6,8 @@
     <id>http://www.zotero.org/styles/huazhong-university-of-science-and-technology</id>
     <link href="http://www.zotero.org/styles/huazhong-university-of-science-and-technology" rel="self"/>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
-    <link href="https://aia.hust.edu.cn/info/1122/5294.htm" rel="documentation"/>
+    <link href="http://cse.hust.edu.cn/yjsjy/wjxz.htm" rel="documentation"/>
+    <link href="http://gs.hust.edu.cn/info/1022/1027.htm" rel="reference"/>
     <author>
       <name>韩小土</name>
       <email>redleafnew@163.com</email>
@@ -18,7 +19,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>中文文献（含图书、期刊论文、会议论文、专利等）：作者按中文写法，姓在前、名在后；英文文献（含图书、期刊论文、会议论文、专利等）：作者按英文习惯写法，名在前、姓在后，名和姓均用全称，如果作者名超过两个单词，中间名使用简称，如“C.”，不要混用。3人以内列出全部作者，3人以上列出3人再加“等”（英文加“et al”）。每个参考文献的最后不加标点符号。</summary>
-    <updated>2023-10-10T14:23:10+08:00</updated>
+    <updated>2023-11-30T00:23:10+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
更新链接，标注了现行的论文规范http://gs.hust.edu.cn/info/1022/1027.htm
确实改成3人了。

现在网上没找到完全贴合的公开的模板，贴的那个模板是网安学院放出来的，从标题上可以看出他们是修改过好几次的。
只不过那个模板里的参考文献范例经我查证还存在一些问题，
如它增加了一项专利
`刘德林，李德奎. 多功能可擦写存储器. 中国，发明专利，202010575613.3，2020`，
搜专利号搜出来却是另一项华中科技大学的专利：
`CN111832020A CN202010575613.3 一种安卓应用恶意性、恶意种族检测模型构建方法及应用`
因此没有更新`test/styles`的测试部分。

另外还有一个问题，需要再改一下“（第二版）”这个版本问题。
第一个引用应该是`[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践（第二版）. 北京: 中国水利水电出版社, 2006`，
而现在是`[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践（第二版）. 北京: 中国水利水电出版社, 2006`。
