### PR TITLE
华中科技大学：修改中文专著版本信息的呈现方式，改为（第x版）

### DIFF
--- a/418huazhong-university-of-science-and-technology.csl
+++ b/418huazhong-university-of-science-and-technology.csl
@@ -192,7 +192,7 @@
   <macro name="edition-en">
     <choose>
       <if is-numeric="edition">
-        <number variable="edition" form="ordinal"/>
+        <number variable="edition" form="ordinal" prefix=" "/>
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
@@ -203,10 +203,11 @@
   <!-- 版本项 -->
   <macro name="edition-zh">
     <choose>
+      <!-- 图书名称（第x版） -->
       <if is-numeric="edition">
-        <text value="第"/>
+        <text value="第" prefix="（" />
         <number variable="edition" form="long-ordinal"/>
-        <label variable="edition" form="short"/>
+        <label variable="edition" form="short" suffix="）"/>
       </if>
       <else>
         <text variable="edition"/>
@@ -398,9 +399,11 @@
         </else-if>
         <else>
           <!-- 4.1 专著 -->
-          <text macro="title"/>
+          <group delimiter="">
+            <text macro="title"/>
+            <text macro="edition-zh"/>
+          </group>
           <text macro="secondary-contributors"/>
-          <text macro="edition-zh"/>
           <text macro="publisher"/>
         </else>
       </choose>

--- a/tests/styles/418huazhong-university-of-science-and-technology/README.md
+++ b/tests/styles/418huazhong-university-of-science-and-technology/README.md
@@ -9,7 +9,7 @@
 ## 参考文献表
 
 <div class="csl-bib-body second-field-align-flush">
-  <div class="csl-entry">[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践. 第二版. 北京: 中国水利水电出版社, 2006</div>
+  <div class="csl-entry">[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践（第二版）. 北京: 中国水利水电出版社, 2006</div>
   <div class="csl-entry">[2]	Martin Chalfie, Steven Kain. Green fluorescent protein: properties, applications, and protocols. 2nd ed. Hoboken, New Jersey: Wiley-Interscience, 1998</div>
   <div class="csl-entry">[3]	詹向红, 李德新. 中医药防治阿尔茨海默病实验研究述要. 中华中医药学刊, 2004, 22(11): 2094-2096</div>
   <div class="csl-entry">[4]	Ed S. Lein, Michael J. Hawrylycz, Nancy Ao, et al. Genome-wide atlas of gene expression in the adult mouse brain. Nature, 2007, 445(7124): 168-176</div>


### PR DESCRIPTION
`[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践. 第二版. 北京: 中国水利水电出版社, 2006`，改为`[1]	闫明礼, 张东刚. CFG桩复合地基技术及工程实践（第二版）. 北京: 中国水利水电出版社, 2006`。