### PR TITLE
西北农林科技大学：更新研究生毕业论文样式，新增本科生毕业论文样式

### DIFF
--- a/409northwest-a-and-f-university.csl
+++ b/409northwest-a-and-f-university.csl
@@ -56,8 +56,25 @@
       <term name="page-range-delimiter">~</term>
     </terms>
   </locale>
-  <!-- 主要责任者 -->
-  <macro name="author">
+  <!-- 英文主要责任者 -->
+  <macro name="author-en">
+    <names variable="author">
+      <name delimiter=", "/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 中文主要责任者 -->
+  <macro name="author-zh">
     <names variable="author">
       <name delimiter=","/>
       <substitute>
@@ -593,8 +610,8 @@
   </macro>
   <!-- 参考文献表格式 -->
   <macro name="entry-layout-en">
-    <group delimiter=".">
-      <text macro="author"/>
+    <group delimiter=". ">
+      <text macro="author-en"/>
       <text macro="date"/>
       <choose>
         <if type="periodical">
@@ -640,7 +657,7 @@
   </macro>
   <macro name="entry-layout-zh">
     <group delimiter=".">
-      <text macro="author"/>
+      <text macro="author-zh"/>
       <text macro="date"/>
       <choose>
         <if type="periodical">
@@ -709,7 +726,7 @@
   </citation>
   <bibliography entry-spacing="0" hanging-indent="true">
     <sort>
-      <key macro="author"/>
+      <key macro="author-en"/>
       <key macro="date"/>
     </sort>
     <layout locale="en">

--- a/409northwest-a-and-f-university.csl
+++ b/409northwest-a-and-f-university.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with="" initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>西北农林科技大学（研究生学位论文）</title>
     <title-short>NWAFU</title-short>

--- a/409northwest-a-and-f-university.csl
+++ b/409northwest-a-and-f-university.csl
@@ -165,7 +165,7 @@
   </macro>
   <!-- 题名 -->
   <macro name="title-en">
-    <group delimiter=".">
+    <group delimiter=". ">
       <group delimiter=": ">
         <text variable="title"/>
         <group delimiter="&#8195;">
@@ -368,8 +368,33 @@
       </if>
     </choose>
   </macro>
-  <!-- 连续出版物中的出处项 -->
-  <macro name="container-periodical">
+  <!-- 英文连续出版物中的出处项 -->
+  <macro name="container-periodical-en">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项：“刊名, 出版日期(版次): 页码” -->
+        <group delimiter=", ">
+          <text variable="container-title" form="short" strip-periods="true"/>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码” -->
+        <group delimiter=": ">
+          <group>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" strip-periods="true"/>
+              <text variable="volume"/>
+            </group>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- 中文连续出版物中的出处项 -->
+  <macro name="container-periodical-zh">
     <choose>
       <if type="article-newspaper">
         <!-- 报纸的出处项：“刊名,出版日期(版次):页码” -->
@@ -439,7 +464,7 @@
   <macro name="publisher-en">
     <choose>
       <if type="patent">
-        <group delimiter=",">
+        <group delimiter=", ">
           <group delimiter=" ">
             <text macro="patent-country-en"/>
             <text macro="patent-type-en"/>
@@ -448,23 +473,23 @@
         </group>
       </if>
       <else-if type="paper-conference">
-        <!-- 会议论文集的格式“出版者,页码”（出版者为会议名称） -->
-        <group delimiter=",">
+        <!-- 会议论文集的格式“出版者, 页码”（出版者为会议名称） -->
+        <group delimiter=", ">
           <text variable="publisher"/>
           <text variable="page"/>
         </group>
       </else-if>
       <else-if type="book chapter classic entry-dictionary entry-encyclopedia thesis">
-        <!-- 专著、学位论文的格式“出版地:出版者” -->
-        <group delimiter=":">
+        <!-- 专著、学位论文的格式“出版地: 出版者” -->
+        <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
         </group>
       </else-if>
       <else-if type="periodical" variable="archive archive-place publisher publisher-place page" match="any">
-        <!-- 期刊的格式“出版地:出版者:页码” -->
-        <group delimiter=":">
-          <group delimiter=":">
+        <!-- 期刊的格式“出版地: 出版者: 页码” -->
+        <group delimiter=": ">
+          <group delimiter=": ">
             <choose>
               <if variable="publisher publisher-place" match="any">
                 <text variable="publisher-place"/>
@@ -623,7 +648,7 @@
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <!-- 4.4 连续出版物中的析出文献 -->
           <text macro="title-en"/>
-          <text macro="container-periodical"/>
+          <text macro="container-periodical-en"/>
         </else-if>
         <else-if type="patent">
           <!-- 4.5 专利文献 -->
@@ -669,7 +694,7 @@
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <!-- 4.4 连续出版物中的析出文献 -->
           <text macro="title-zh"/>
-          <text macro="container-periodical"/>
+          <text macro="container-periodical-zh"/>
         </else-if>
         <else-if type="patent">
           <!-- 4.5 专利文献 -->

--- a/409northwest-a-and-f-university.csl
+++ b/409northwest-a-and-f-university.csl
@@ -53,7 +53,7 @@
       <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
     </date>
     <terms>
-      <term name="page-range-delimiter">~</term>
+      <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
   <!-- 英文主要责任者 -->

--- a/480northwest-a-and-f-university-undergraduate.csl
+++ b/480northwest-a-and-f-university-undergraduate.csl
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
-    <title>西北农林科技大学（研究生学位论文）</title>
-    <title-short>NWAFU</title-short>
-    <id>http://www.zotero.org/styles/northwest-a-and-f-university</id>
-    <link href="http://www.zotero.org/styles/northwest-a-and-f-university" rel="self"/>
+    <title>西北农林科技大学（本科生毕业论文）</title>
+    <title-short>NWAFU-Undergraduate</title-short>
+    <id>http://www.zotero.org/styles/northwest-a-and-f-university-undergraduate</id>
+    <link href="http://www.zotero.org/styles/northwest-a-and-f-university-undergraduate" rel="self"/>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-author-date" rel="template"/>
-    <link href="https://yjshy.nwafu.edu.cn/xwgl/xwsy/xwlwxzgf/8ae4dda6e6be4ac6895f509d84bc68c3.htm" rel="documentation"/>
+    <link href="https://sjxy.nwafu.edu.cn/docs//2023-10/b9a480391e4c4a54a7bbbeabe796aeaa.doc" rel="documentation"/>
     <author>
       <name>YuYuYu</name>
       <email>hachitako@qq.com</email>
@@ -25,7 +25,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>西北农林科技大学（研究生学位论文）</summary>
+    <summary>西北农林科技大学本科生毕业论文（设计）</summary>
     <updated>2024-03-29T10:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -59,7 +59,7 @@
   <!-- 主要责任者 -->
   <macro name="author">
     <names variable="author">
-      <name delimiter=","/>
+      <name/>
       <substitute>
         <names variable="composer"/>
         <names variable="illustrator"/>
@@ -148,7 +148,7 @@
   </macro>
   <!-- 题名 -->
   <macro name="title-en">
-    <group delimiter=".">
+    <group delimiter=". ">
       <group delimiter=": ">
         <text variable="title"/>
         <group delimiter="&#8195;">
@@ -178,13 +178,9 @@
         </if>
       </choose>
     </group>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-id"/>
-      <text macro="medium-id"/>
-    </group>
   </macro>
   <macro name="title-zh">
-    <group delimiter=".">
+    <group delimiter=". ">
       <group delimiter=": ">
         <text variable="title"/>
         <group delimiter="&#8195;">
@@ -214,10 +210,6 @@
         </if>
       </choose>
     </group>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-id"/>
-      <text macro="medium-id"/>
-    </group>
   </macro>
   <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
   <macro name="volume">
@@ -237,70 +229,25 @@
       </if>
     </choose>
   </macro>
-  <!-- 文献类型标识 -->
-  <macro name="type-id">
+  <!-- 学位论文类型 -->
+  <macro name="thesis-type-en">
     <choose>
-      <if type="article bill collection hearing legal_case legislation personal_communication regulation treaty" match="any">
-        <!-- 档案，A：分类保存以备查考的文件和材料，如人事档案、科技档案、法律法规、政府文件等。
-          article 为预印本，符合“科技档案”
-        -->
-        <text value="A"/>
+      <if variable="genre">
+        <text variable="genre" prefix="[" suffix="]"/>
       </if>
-      <else-if type="article-journal article-magazine periodical" match="any">
-        <text value="J"/>
-      </else-if>
-      <else-if type="article-newspaper">
-        <text value="N"/>
-      </else-if>
-      <else-if type="book chapter classic entry-dictionary entry-encyclopedia" match="any">
-        <text value="M"/>
-      </else-if>
-      <else-if type="dataset">
-        <text value="DS"/>
-      </else-if>
-      <else-if type="map">
-        <text value="CM"/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text value="C"/>
-      </else-if>
-      <else-if type="patent">
-        <text value="P"/>
-      </else-if>
-      <else-if type="post post-weblog webpage" match="any">
-        <text value="EB"/>
-      </else-if>
-      <else-if type="report">
-        <text value="R"/>
-      </else-if>
-      <else-if type="software">
-        <text value="CP"/>
-      </else-if>
-      <else-if type="standard">
-        <text value="S"/>
-      </else-if>
-      <else-if type="thesis">
-        <text value="D"/>
-      </else-if>
       <else>
-        <text value="Z"/>
+        <text value="[PhD dissertation]"/>
       </else>
     </choose>
   </macro>
-  <!-- 文献载体标识 -->
-  <macro name="medium-id">
+  <macro name="thesis-type-zh">
     <choose>
-      <if type="dataset post post-weblog software webpage" match="any">
-        <!-- 仅当纯电子资源显示 URL 时才出现“OL” -->
-        <choose>
-          <if variable="medium">
-            <text variable="medium"/>
-          </if>
-          <else-if variable="URL">
-            <text value="OL"/>
-          </else-if>
-        </choose>
+      <if variable="genre">
+        <text variable="genre" prefix="[" suffix="]"/>
       </if>
+      <else>
+        <text value="[博士学位论文]"/>
+      </else>
     </choose>
   </macro>
   <!-- 其他责任者 -->
@@ -332,19 +279,20 @@
   <macro name="container-booklike">
     <choose>
       <if variable="container-title">
-        <text term="in" text-case="capitalize-first" suffix=":"/>
-        <group delimiter=".">
+        <text term="in" text-case="capitalize-first" suffix=": "/>
+        <group delimiter=". ">
           <text macro="container-contributors"/>
           <choose>
-            <if type="paper-conference">
-              <!-- 会议论文集不使用此项 -->
-            </if>
-            <else-if variable="container-title">
+            <if variable="container-title">
               <!-- 优先使用专著或会议论文集的题名 -->
-              <group delimiter=":">
+              <group delimiter=": ">
                 <text variable="container-title"/>
                 <text macro="volume"/>
               </group>
+            </if>
+            <else-if type="paper-conference">
+              <!-- 有些会议没有论文集，使用会议名代替 -->
+              <text variable="event-title"/>
             </else-if>
           </choose>
         </group>
@@ -355,18 +303,18 @@
   <macro name="container-periodical">
     <choose>
       <if type="article-newspaper">
-        <!-- 报纸的出处项：“刊名,出版日期(版次):页码” -->
-        <group delimiter=",">
-          <text variable="container-title" form="short" strip-periods="true"/>
+        <!-- 报纸的出处项：“刊名, 出版日期(版次): 页码[引用日期]” -->
+        <group delimiter=", ">
+          <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
           <text variable="page"/>
         </group>
       </if>
       <else>
-        <!-- 期刊、杂志的出处项：“刊名,卷(期):页码” -->
-        <group delimiter=":">
+        <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
+        <group delimiter=": ">
           <group>
-            <group delimiter=",">
-              <text variable="container-title" form="short" strip-periods="true"/>
+            <group delimiter=", ">
+              <text variable="container-title" strip-periods="true" font-style="italic"/>
               <text variable="volume"/>
             </group>
             <text variable="issue" prefix="(" suffix=")"/>
@@ -404,7 +352,7 @@
   </macro>
   <!-- 连续出版物的年卷期 -->
   <macro name="year-volume-issue">
-    <group delimiter=",">
+    <group delimiter=", ">
       <text macro="date"/>
       <text variable="volume"/>
     </group>
@@ -422,7 +370,7 @@
   <macro name="publisher-en">
     <choose>
       <if type="patent">
-        <group delimiter=",">
+        <group delimiter=", ">
           <group delimiter=" ">
             <text macro="patent-country-en"/>
             <text macro="patent-type-en"/>
@@ -430,24 +378,10 @@
           <text variable="number"/>
         </group>
       </if>
-      <else-if type="paper-conference">
-        <!-- 会议论文集的格式“出版者,页码”（出版者为会议名称） -->
-        <group delimiter=",">
-          <text variable="publisher"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else-if type="book chapter classic entry-dictionary entry-encyclopedia thesis">
-        <!-- 专著、学位论文的格式“出版地:出版者” -->
-        <group delimiter=":">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="periodical" variable="archive archive-place publisher publisher-place page" match="any">
-        <!-- 期刊的格式“出版地:出版者:页码” -->
-        <group delimiter=":">
-          <group delimiter=":">
+      <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
+        <!-- 非纯电子资源的格式“出版地: 出版者: 页码[引用日期]” -->
+        <group delimiter=": ">
+          <group delimiter=": ">
             <choose>
               <if variable="publisher publisher-place" match="any">
                 <text variable="publisher-place"/>
@@ -468,7 +402,7 @@
   <macro name="publisher-zh">
     <choose>
       <if type="patent">
-        <group delimiter=",">
+        <group delimiter=", ">
           <group>
             <text macro="patent-country-zh"/>
             <text macro="patent-type-zh"/>
@@ -476,24 +410,10 @@
           <text variable="number"/>
         </group>
       </if>
-      <else-if type="paper-conference">
-        <!-- 会议论文集的格式“出版者,页码”（出版者为会议名称） -->
-        <group delimiter=",">
-          <text variable="publisher"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else-if type="book chapter classic entry-dictionary entry-encyclopedia thesis">
-        <!-- 专著、学位论文的格式“出版地:出版者” -->
-        <group delimiter=":">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="periodical" variable="archive archive-place publisher publisher-place page" match="any">
-        <!-- 期刊的格式“出版地:出版者:页码” -->
-        <group delimiter=":">
-          <group delimiter=":">
+      <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
+        <!-- 非纯电子资源的格式“出版地: 出版者: 页码[引用日期]” -->
+        <group delimiter=": ">
+          <group delimiter=": ">
             <choose>
               <if variable="publisher publisher-place" match="any">
                 <text variable="publisher-place"/>
@@ -570,6 +490,7 @@
             <group delimiter=" ">
               <!-- 仅纯电子资源显示 URL -->
               <text variable="URL"/>
+              <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
             </group>
           </if>
         </choose>
@@ -593,7 +514,7 @@
   </macro>
   <!-- 参考文献表格式 -->
   <macro name="entry-layout-en">
-    <group delimiter=".">
+    <group delimiter=". ">
       <text macro="author"/>
       <text macro="date"/>
       <choose>
@@ -639,7 +560,7 @@
     </group>
   </macro>
   <macro name="entry-layout-zh">
-    <group delimiter=".">
+    <group delimiter=". ">
       <text macro="author"/>
       <text macro="date"/>
       <choose>
@@ -688,8 +609,8 @@
     <sort>
       <key macro="author-intext-en"/>
     </sort>
-    <layout prefix="（" suffix="）" delimiter="; " locale="en">
-      <group delimiter=":">
+    <layout prefix="(" suffix=")" delimiter="; " locale="en">
+      <group delimiter=": ">
         <group delimiter=" ">
           <text macro="author-intext-en"/>
           <text macro="date-intext"/>
@@ -697,8 +618,8 @@
         <text macro="locator"/>
       </group>
     </layout>
-    <layout prefix="（" suffix="）" delimiter="; ">
-      <group delimiter=":">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=": ">
         <group delimiter=" ">
           <text macro="author-intext-zh"/>
           <text macro="date-intext"/>
@@ -713,10 +634,10 @@
       <key macro="date"/>
     </sort>
     <layout locale="en">
-      <text macro="entry-layout-en" suffix="."/>
+      <text macro="entry-layout-en"/>
     </layout>
     <layout>
-      <text macro="entry-layout-zh" suffix="."/>
+      <text macro="entry-layout-zh"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
### 西北农林科技大学样式更新
- 409 研究生样式：按照2024年3月14日发布的新版[《西北农林科技大学研究生学位论文撰写规范指导意见》](https://yjshy.nwafu.edu.cn/xwgl/xwsy/xwlwxzgf/8ae4dda6e6be4ac6895f509d84bc68c3.htm)中的[附件2](https://yjshy.nwafu.edu.cn/docs//2024-03/42414f1637e74f218d1a433c5fd31c27.pdf)进行调整。
- 480 本科生样式：按照西农水利与建筑工程学院发布的[《关于2024届本科毕业论文（设计）开题工作安排的通知》](https://sjxy.nwsuaf.edu.cn/tzggB/c371c167584f4a6aba1575243b38e8a1.htm)中的[附件5](https://sjxy.nwsuaf.edu.cn/docs//2023-10/b9a480391e4c4a54a7bbbeabe796aeaa.doc)，基于原409西北农林科技大学样式进行调整。
  - 由于未直接从校级单位找到相关要求文件，已与西农其它学院相关通知内的文件进行比对，样式一致。

~~### 需要帮助~~
~~研究生毕业论文样式中，著录部分英文作者应显示为Reed BM，但当前会显示为Reed B M。麻烦大佬帮帮忙OvO~~