### PR TITLE
新增生物化学与生物物理进展

### DIFF
--- a/125progress-in-biochemistry-and-biophysics.csl
+++ b/125progress-in-biochemistry-and-biophysics.csl
@@ -1,0 +1,552 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
+  <info>
+    <title>生物化学与生物物理进展</title>
+    <id>http://www.zotero.org/styles/progress-in-biochemistry-and-biophysics</id>
+    <link href="http://www.zotero.org/styles/progress-in-biochemistry-and-biophysics" rel="self"/>
+    <link href="http://www.zotero.org/styles/chinese-gb7714-1987-numeric" rel="template"/>
+    <link href="http://gxb.zzu.edu.cn/Upload/Park/ccc5c171-124b-4f01-a4d0-44db19516ff8.pdf" rel="documentation"/>
+    <author>
+      <name>aoaim</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <updated>2024-05-28T15:32:15+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="thesis">dissertation</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh">
+    <terms>
+      <term name="edition" form="short">版</term>
+      <term name="in">见</term>
+      <term name="patent">专利</term>
+      <term name="thesis">学位论文</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="editor" form="short">主编</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="page-range-delimiter">～</term>
+    </terms>
+  </locale>
+  <!-- 主要责任者 -->
+  <macro name="author-en">
+    <names variable="author">
+      <name/>
+      <label form="short" prefix=", "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-zh">
+    <names variable="author">
+      <name delimiter="，"/>
+      <label form="short"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title-en">
+    <group delimiter=": ">
+      <group delimiter=" ">
+        <choose>
+          <if type="standard">
+            <text variable="number"/>
+          </if>
+        </choose>
+        <text variable="title"/>
+        <choose>
+          <if variable="container-title" type="chapter paper-conference" match="none">
+            <text macro="volume"/>
+          </if>
+        </choose>
+        <choose>
+          <if type="bill legal_case legislation regulation report" match="any">
+            <text variable="number"/>
+          </if>
+        </choose>
+      </group>
+      <choose>
+        <if type="thesis">
+          <text term="thesis" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="title-zh">
+    <group delimiter="：">
+      <group delimiter=" ">
+        <choose>
+          <if type="standard">
+            <text variable="number"/>
+          </if>
+        </choose>
+        <group delimiter="：">
+          <text variable="title"/>
+          <group delimiter="&#8195;">
+            <choose>
+              <if variable="container-title" type="chapter paper-conference" match="none">
+                <text macro="volume"/>
+              </if>
+            </choose>
+            <choose>
+              <if type="bill legal_case legislation regulation report" match="any">
+                <text variable="number"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+      </group>
+      <choose>
+        <if type="thesis">
+          <text term="thesis" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributors-en">
+    <names variable="translator">
+      <name/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="secondary-contributors-zh">
+    <names variable="translator">
+      <name delimiter="，"/>
+      <label form="short"/>
+    </names>
+  </macro>
+  <!-- 专著主要责任者 -->
+  <macro name="container-contributors-en">
+    <names variable="editor">
+      <name/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-contributors-zh">
+    <names variable="editor">
+      <name delimiter="，"/>
+      <label form="short"/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-booklike-en">
+    <group delimiter=": ">
+      <text term="in" text-case="capitalize-first"/>
+      <group delimiter=". ">
+        <text macro="container-contributors-en"/>
+        <group delimiter=", ">
+          <choose>
+            <if variable="container-title">
+              <!-- 优先使用专著或会议论文集的题名 -->
+              <group delimiter=": ">
+                <text variable="container-title"/>
+                <text macro="volume"/>
+              </group>
+            </if>
+            <else-if type="paper-conference">
+              <!-- 有些会议没有论文集，使用会议名代替 -->
+              <text variable="event-title"/>
+            </else-if>
+          </choose>
+          <!-- 会议时间和会议地点 -->
+          <choose>
+            <if type="paper-conference" variable="event-date" match="all">
+              <date variable="event-date" form="numeric" date-parts="year"/>
+              <text variable="event-place"/>
+            </if>
+          </choose>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-booklike-zh">
+    <group delimiter="：">
+      <text term="in" text-case="capitalize-first"/>
+      <group delimiter="．">
+        <text macro="container-contributors-zh"/>
+        <group delimiter="，">
+          <choose>
+            <if variable="container-title">
+              <!-- 优先使用专著或会议论文集的题名 -->
+              <group delimiter="：">
+                <text variable="container-title"/>
+                <text macro="volume"/>
+              </group>
+            </if>
+            <else-if type="paper-conference">
+              <!-- 有些会议没有论文集，使用会议名代替 -->
+              <text variable="event-title"/>
+            </else-if>
+          </choose>
+          <!-- 会议时间和会议地点 -->
+          <choose>
+            <if type="paper-conference" variable="event-date" match="all">
+              <date variable="event-date" form="numeric" date-parts="year"/>
+              <text variable="event-place"/>
+            </if>
+          </choose>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- 连续出版物中的出处项 -->
+  <macro name="container-periodical-en">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项：“刊名, 出版日期(版次): 页码[引用日期]” -->
+        <group delimiter=", ">
+          <text variable="container-title" form="short" strip-periods="true"/>
+          <date variable="issued" form="numeric"/>
+        </group>
+        <text variable="page" prefix="(" suffix=")"/>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
+        <group delimiter=": ">
+          <group>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" strip-periods="true"/>
+              <date variable="issued" form="numeric" date-parts="year"/>
+              <text variable="volume" font-weight="bold"/>
+            </group>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-periodical-zh">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项：“刊名，出版日期（版次）：页码［引用日期］” -->
+        <group delimiter="，">
+          <text variable="container-title" form="short" strip-periods="true"/>
+          <date variable="issued" form="numeric"/>
+        </group>
+        <text variable="page" prefix="（" suffix="）"/>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
+        <group delimiter="：">
+          <group>
+            <group delimiter="，">
+              <text variable="container-title" form="short" strip-periods="true"/>
+              <date variable="issued" form="numeric" date-parts="year"/>
+              <text variable="volume" font-weight="bold"/>
+            </group>
+            <text variable="issue" prefix="（" suffix="）"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition-en">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition-zh">
+    <choose>
+      <if is-numeric="edition">
+        <text value="第"/>
+        <number variable="edition"/>
+        <label variable="edition" form="short"/>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue-en">
+    <group delimiter=", ">
+      <date variable="issued" form="numeric" date-parts="year"/>
+      <text variable="volume"/>
+    </group>
+    <text variable="issue" prefix="(" suffix=")"/>
+  </macro>
+  <macro name="year-volume-issue-zh">
+    <group delimiter="，">
+      <date variable="issued" form="numeric" date-parts="year"/>
+      <text variable="volume"/>
+    </group>
+    <text variable="issue" prefix="（" suffix="）"/>
+  </macro>
+  <!-- 出版项 -->
+  <macro name="publisher-en">
+    <choose>
+      <if type="patent">
+        <!-- 专利的出版项” -->
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="patent-country-en"/>
+              <text term="patent"/>
+            </group>
+            <text variable="number"/>
+          </group>
+          <date variable="issued" form="numeric"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <group delimiter=", ">
+            <group delimiter=": ">
+              <text variable="publisher-place"/>
+              <text variable="publisher" strip-periods="true"/>
+            </group>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-zh">
+    <choose>
+      <if type="patent">
+        <!-- 专利的出版项” -->
+        <group delimiter="．">
+          <group delimiter="，">
+            <group>
+              <text macro="patent-country-zh"/>
+              <text term="patent"/>
+            </group>
+            <text variable="number"/>
+          </group>
+          <date variable="issued" form="numeric"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter="：">
+          <group delimiter="，">
+            <group delimiter="：">
+              <text variable="publisher-place"/>
+              <text variable="publisher" strip-periods="true"/>
+            </group>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专利国别 -->
+  <macro name="patent-country-en">
+    <choose>
+      <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 的 `Country` 字段没有映射到 CSL，所以使用 `publisher-place` 作为备选 -->
+      <if variable="jurisdiction">
+        <text variable="jurisdiction"/>
+      </if>
+      <else-if variable="publisher-place">
+        <text variable="publisher-place"/>
+      </else-if>
+      <else>
+        <text value="US"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="patent-country-zh">
+    <choose>
+      <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 的 `Country` 字段没有映射到 CSL，所以使用 `publisher-place` 作为备选 -->
+      <if variable="jurisdiction">
+        <text variable="jurisdiction"/>
+      </if>
+      <else-if variable="publisher-place">
+        <text variable="publisher-place"/>
+      </else-if>
+      <else>
+        <text value="中国"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 获取和访问路径、数字对象唯一标识符 -->
+  <macro name="access">
+    <choose>
+      <if type="dataset post post-weblog software webpage" match="any">
+        <!-- 仅纯电子资源显示 URL -->
+        <text variable="URL"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout-en">
+    <group delimiter=". ">
+      <text macro="author-en"/>
+      <choose>
+        <if type="periodical">
+          <!-- 4.3 连续出版物 -->
+          <text macro="title-en"/>
+          <text macro="year-volume-issue-en"/>
+          <text macro="publisher-en"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <!-- 4.4 连续出版物中的析出文献 -->
+          <text macro="title-en"/>
+          <text macro="container-periodical-en"/>
+        </else-if>
+        <else-if type="patent">
+          <!-- 4.5 专利文献 -->
+          <text macro="title-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else-if type="dataset post post-weblog software webpage" match="any">
+          <!-- 4.6 电子资源 -->
+          <text macro="title-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" variable="container-title" match="any">
+          <!-- 4.2 专著中的析出文献 -->
+          <text macro="title-en"/>
+          <text macro="secondary-contributors-en"/>
+          <text macro="container-booklike-en"/>
+          <text macro="edition-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else>
+          <!-- 4.1 专著 -->
+          <text macro="title-en"/>
+          <text macro="edition-en"/>
+          <text macro="secondary-contributors-en"/>
+          <text macro="publisher-en"/>
+        </else>
+      </choose>
+      <text macro="access"/>
+    </group>
+  </macro>
+  <macro name="entry-layout-zh">
+    <group delimiter="．">
+      <text macro="author-zh"/>
+      <choose>
+        <if type="periodical">
+          <!-- 4.3 连续出版物 -->
+          <text macro="title-zh"/>
+          <text macro="year-volume-issue-zh"/>
+          <text macro="publisher-zh"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <!-- 4.4 连续出版物中的析出文献 -->
+          <text macro="title-zh"/>
+          <text macro="container-periodical-zh"/>
+        </else-if>
+        <else-if type="patent">
+          <!-- 4.5 专利文献 -->
+          <text macro="title-zh"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else-if type="dataset post post-weblog software webpage" match="any">
+          <!-- 4.6 电子资源 -->
+          <text macro="title-zh"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" variable="container-title" match="any">
+          <!-- 4.2 专著中的析出文献 -->
+          <text macro="title-zh"/>
+          <text macro="secondary-contributors-zh"/>
+          <text macro="container-booklike-zh"/>
+          <text macro="edition-zh"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else>
+          <!-- 4.1 专著 -->
+          <text macro="title-zh"/>
+          <text macro="edition-zh"/>
+          <text macro="secondary-contributors-zh"/>
+          <text macro="publisher-zh"/>
+        </else>
+      </choose>
+      <text macro="access"/>
+    </group>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <layout suffix="." locale="en">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-en"/>
+    </layout>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-zh"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
生物化学与生物物理进展的[官方网站](https://www.pibb.ac.cn/pibbcn/site/menus/68)上说明参考文献使用GB/T7714-2005规范，但是根据其提供的EndNote Style来看并不完全一致，包括省去 [J] 等期刊标志、卷号标粗和 et al 为斜体等。其他格式大多与[中国高等学校自然科学学报编排规范](https://github.com/aoaim/Chinese-STD-GB-T-7714-related-csl/blob/main/022journals-of-natural-sciences-in-chinese-universities.csl)一致，因此基于此蓝本修改而来。

杂志官方EndNote Style效果示例如下：

<sub>[1]</sub>
<sub>[2]</sub>

[1]	Cui Y, Zhang Z, Zhou X, _et al_. Microglia and macrophage exhibit attenuated inflammatory response and ferroptosis resistance after RSL3 stimulation via increasing nrf2 expression. Journal of Neuroinflammation, 2021, **18**(1): 249.
[2]	Edwards D J, Bowles S K, Svensson C K, _et al_. Inhibition of drug metabolism by quinolone antibiotics. Clinical Pharmacokinetics, 1988, **15**(3): 194-204.
